### PR TITLE
Changed Bower repo name

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -12,7 +12,7 @@ title: shine.js
   <div class="container">
     <h3>Get Shine</h3>
     <p>Install using Bower:</p>
-    {% highlight bash %}bower install shinejs{% endhighlight %}
+    {% highlight bash %}bower install shine{% endhighlight %}
     <p>
       <a class="button" href="https://github.com/bigspaceship/shine.js">Fork on GitHub</a>
       <a class="button" href="https://github.com/bigspaceship/shine.js/archive/master.zip">Download as ZIP</a>


### PR DESCRIPTION
The bower repo name is actually just "shine", I've just changed it on the GH page
